### PR TITLE
Corrected error logic

### DIFF
--- a/rl_coach/filters/observation/observation_stacking_filter.py
+++ b/rl_coach/filters/observation/observation_stacking_filter.py
@@ -65,10 +65,10 @@ class ObservationStackingFilter(ObservationFilter):
         self.stack = []
         self.input_observation_space = None
 
-        if stack_size <= 0:
-            raise ValueError("The stack shape must be a positive number")
         if type(stack_size) != int:
-            raise ValueError("The stack shape must be of int type")
+            raise TypeError("The stack shape must be of int type")
+        if stack_size < 2:
+            raise ValueError("Cannot stack less than 2 frames")
 
     @property
     def next_filter(self) -> 'InputFilter':


### PR DESCRIPTION
I see 2 issues with the ObservationStackingFilter object.

The current implementation checks that the input is less than 0, then checks that the input is a number. If it's not a number, the second check will never run. Swapping the order fixes this. This should also be a TypeError, not a ValueError.

Secondly, there is no valid case for stacking 0 or 1 frames, so the code should assert >= 2, not >=0 